### PR TITLE
[test] Added Integration test for Query API Validation . 

### DIFF
--- a/pkg/api/compute.go
+++ b/pkg/api/compute.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GetCompute requests GET /model/allocation/compute
+func (api *API) GetCompute(req ComputeRequest) (*ComputeResponse, error) {
+	resp := &ComputeResponse{}
+
+	err := api.GET("/model/allocation/compute", req, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+type ComputeRequest struct {
+	Accumulate                 string
+	Aggregate                  string
+	Idle                       string
+	Step					   string
+	Window                     string
+}
+
+func (ar ComputeRequest) QueryString() string {
+	params := []string{}
+
+	params = append(params, fmt.Sprintf("accumulate=%s", ar.Accumulate))
+	params = append(params, fmt.Sprintf("aggregate=%s", ar.Aggregate))
+	params = append(params, fmt.Sprintf("includeIdle=%s", ar.Idle))
+	params = append(params, fmt.Sprintf("window=%s", ar.Window))
+
+	return fmt.Sprintf("?%s", strings.Join(params, "&"))
+}
+
+type ComputeResponse struct {
+	Code int                                 `json:"code"`
+	Data []map[string]ComputeResponseItem `json:"data"`
+}
+
+type ComputeResponseItem struct {
+	Name                           string                                  `json:"name"`
+	Properties                     *AllocationResponseItemProperties       `json:"properties"`
+	Window                         Window                                  `json:"window"`
+	Start                          time.Time                               `json:"start"`
+	End                            time.Time                               `json:"end"`
+	CPUCoreHours                   float64                                 `json:"cpuCoreHours"`
+	CPUCoreRequestAverage          float64                                 `json:"cpuCoreRequestAverage"`
+	CPUCoreUsageAverage            float64                                 `json:"cpuCoreUsageAverage"`
+	CPUCost                        float64                                 `json:"cpuCost"`
+	CPUCostAdjustment              float64                                 `json:"cpuCostAdjustment"`
+	CPUCostIdle                    float64                                 `json:"cpuCostIdle"`
+	GPUHours                       float64                                 `json:"gpuHours"`
+	GPUCost                        float64                                 `json:"gpuCost"`
+	GPUCostAdjustment              float64                                 `json:"gpuCostAdjustment"`
+	GPUCostIdle                    float64                                 `json:"gpuCostIdle"`
+	NetworkTransferBytes           float64                                 `json:"networkTransferBytes"`
+	NetworkReceiveBytes            float64                                 `json:"networkReceiveBytes"`
+	NetworkCost                    float64                                 `json:"networkCost"`
+	NetworkCrossZoneCost           float64                                 `json:"networkCrossZoneCost"`
+	NetworkCrossRegionCost         float64                                 `json:"networkCrossRegionCost"`
+	NetworkInternetCost            float64                                 `json:"networkInternetCost"`
+	NetworkCostAdjustment          float64                                 `json:"networkCostAdjustment"`
+	LoadBalancerCost               float64                                 `json:"loadBalancerCost"`
+	LoadBalancerCostAdjustment     float64                                 `json:"loadBalancerCostAdjustment"`
+	PersistentVolumes              AllocationResponseItemPersistentVolumes `json:"pvs"`
+	PersistentVolumeCostAdjustment float64                                 `json:"pvCostAdjustment"`
+	RAMByteHours                   float64                                 `json:"ramByteHours"`
+	RAMBytesRequestAverage         float64                                 `json:"ramByteRequestAverage"`
+	RAMBytesUsageAverage           float64                                 `json:"ramByteUsageAverage"`
+	RAMCost                        float64                                 `json:"ramCost"`
+	RAMCostAdjustment              float64                                 `json:"ramCostAdjustment"`
+	RAMCostIdle                    float64                                 `json:"ramCostIdle"`
+	SharedCost                     float64                                 `json:"sharedCost"`
+	TotalCost                      float64                                 `json:"totalCost"`
+	TotalEfficiency                float64                                 `json:"totalEfficiency"`
+}
+
+func (ari ComputeResponseItem) PersistentVolumeCost() float64 {
+	if ari.PersistentVolumes == nil {
+		return 0.0
+	}
+
+	cost := 0.0
+
+	for _, pv := range ari.PersistentVolumes {
+		cost += pv.Cost
+	}
+
+	return cost
+}
+
+type ComputeResponseItemProperties struct {
+	Cluster              string            `json:"cluster"`
+	Node                 string            `json:"node"`
+	Container            string            `json:"container"`
+	Controller           string            `json:"controller"`
+	ControllerKind       string            `json:"controllerKind"`
+	Namespace            string            `json:"namespace"`
+	Pod                  string            `json:"pod"`
+	Services             []string          `json:"services"`
+	ProviderID           string            `json:"providerID"`
+	Labels               map[string]string `json:"labels"`
+	Annotations          map[string]string `json:"annotations"`
+	NamespaceLabels      map[string]string `json:"namespaceLabels"`
+	NamespaceAnnotations map[string]string `json:"namespaceAnnotations"`
+}
+
+type ComputeResponseItemPersistentVolumes map[string]ComputeResponseItemPersistentVolume
+
+type ComputeResponseItemPersistentVolume struct {
+	ByteHours  float64 `json:"byteHours"`
+	Cost       float64 `json:"cost"`
+	ProviderID string  `json:"providerID"`
+	Adjustment float64 `json:"adjustment"`
+}
+
+type ComputeComparisonAPI struct {
+	api *API
+}
+
+func NewComputeComparisonAPI(api *API) *ComputeComparisonAPI {
+	return &ComputeComparisonAPI{api: api}
+}
+
+func (a *ComputeComparisonAPI) Get(request interface{}) (interface{}, error) {
+	response, err := a.api.GetCompute(request.(ComputeRequest))
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Code != http.StatusOK {
+		return nil, fmt.Errorf("error code: %d", response.Code)
+	}
+
+	return response, nil
+}

--- a/test/integration/query/validation/test.bats
+++ b/test/integration/query/validation/test.bats
@@ -1,0 +1,11 @@
+setup() {
+    : # nothing to set up
+}
+
+teardown() {
+    : # nothing to tear down
+}
+
+@test "query api : validation of api response" {
+    go test -v ./test/integration/query/validation/validation_test.go
+}

--- a/test/integration/query/validation/validation_test.go
+++ b/test/integration/query/validation/validation_test.go
@@ -1,0 +1,95 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+func TestValidateResponseData(t *testing.T) {
+	a := api.NewAPI()
+
+	resp, err := a.GetCompute(api.ComputeRequest{
+		Accumulate: "false",
+		Window:     "1d",
+		Aggregate:  "namespace",
+		Idle:       "true",
+		Step:       "1d",
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to get compute: %v", err)
+	}
+
+	if resp.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d", resp.Code)
+	}
+
+	if len(resp.Data) == 0 || len(resp.Data[0]) == 0 {
+		t.Fatal("Expected non-empty data response")
+	}
+
+	type TestCase struct {
+		Name     string
+		Check    func(v api.ComputeResponseItem) bool
+		ErrorMsg string
+	}
+
+	testCases := []TestCase{
+		{
+			Name: "NegativeCost",
+			Check: func(v api.ComputeResponseItem) bool {
+				return v.CPUCost < 0 || v.GPUCost < 0 || v.RAMCost < 0 || v.TotalCost < 0 
+			},
+			ErrorMsg: "Negative cost detected",
+		},
+		{
+			Name: "ZeroUsageNonZeroCost",
+			Check: func(v api.ComputeResponseItem) bool {
+				return (v.CPUCoreHours == 0 && v.CPUCost > 0) || (v.GPUHours == 0 && v.GPUCost > 0)
+			},
+			ErrorMsg: "Non-zero cost despite zero usage",
+		},
+		{
+			Name: "TotalEfficiencyOutOfBounds",
+			Check: func(v api.ComputeResponseItem) bool {
+				return v.TotalEfficiency < 0 || v.TotalEfficiency > 1
+			},
+			ErrorMsg: "Total efficiency is out of bounds [0, 1]",
+		},
+		{
+			Name: "StartAfterEnd",
+			Check: func(v api.ComputeResponseItem) bool {
+				return v.Start.After(v.End)
+			},
+			ErrorMsg: "Start time is after end time",
+		},
+		{
+			Name: "NetworkUsageWithoutCost",
+			Check: func(v api.ComputeResponseItem) bool {
+				return v.NetworkTransferBytes > 0 && v.NetworkCost == 0
+			},
+			ErrorMsg: "Network usage reported but no cost",
+		},
+		{
+			Name: "CostMismatch",
+			Check: func(v api.ComputeResponseItem) bool {
+				components := v.CPUCost + v.GPUCost + v.RAMCost + v.NetworkCost + v.LoadBalancerCost + v.SharedCost
+				diff := components - v.TotalCost
+				return diff > 0.01 || diff < -0.01 // Allowing float tolerance
+			},
+			ErrorMsg: "Total cost mismatch with component costs",
+		},
+	}
+
+	for k, v := range resp.Data[0] {
+		t.Run(fmt.Sprintf("Namespace=%s", k), func(t *testing.T) {
+			for _, tc := range testCases {
+				if tc.Check(v) {
+					t.Errorf("[%s] %s: %+v", tc.Name, tc.ErrorMsg, v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### PR Title:
**Add integration tests for Compute API response validation using updated Allocation API**

### Description:
This PR introduces integration tests to validate the response from the `/model/allocation/compute` endpoint, replicating the data shown in the OpenCost UI at [demo.infra.opencost.io](https://demo.infra.opencost.io/?window=1d&agg=namespace) with specific query parameters.

### Changes:
- **Modified URL for Querying** changed the URL to "https://demo.infra.opencost.io" using environment variables . 
- **Modified Allocation API wrapper** in the `pkg/api` directory to support requests to `/model/allocation/compute` with the following query parameters:
  - `window=1d`
  - `accumulate=false`
  - `aggregate=namespace`
  - `idle=true`
  - `step=1d`
  - These parameters can easily be changed and we can do the testing for other  parameters easily if required in future .
- **Added integration tests** in the `validation` package that:
  - Verify successful API response (HTTP 200).
  - Ensure `Data` field is non-empty and structured correctly.
  - Use a test matrix to validate all key cost and usage-related fields:
    - `CPUCost`, `GPUCost`, `RAMCost`, `TotalCost`, `NetworkCost`, etc.
  - Check that required fields are present in every `ComputeResponseItem`.
  - Assert `totalEfficiency` is within the valid range of **0.0 to 1.0**.
  - Ensure Cost For CPU,GPU is zero for zero Usage hours.
  - Network bandwidth cost is zero according to zero data transferred.
  - Assert that all timestamps (`Start`, `End`) are not zero.
  - Log all keys and values for each namespace for easier debugging.

### Notes:
- Helps catch data integrity issues and unintended negative cost values.
- Validated other data parameters . 
- Apart from mentioned requirement , Added other test to catch anomalies.

### Running the test 
![FIRST_OC](https://github.com/user-attachments/assets/af9eb907-2669-4410-b853-0564df591056)

### Failed test 
- Here NegativeCost test has failed for __idle__

![SECOND_OC](https://github.com/user-attachments/assets/e599f774-c436-403d-96da-206c4984918f)
